### PR TITLE
Define development and test dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,8 @@ jobs:
       - name: Install build and test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black
-          pip install flake8
-          pip install mypy
-          pip install responses
+          pip install --editable .[dev]
+          pip install --editable .[test]
       - name: Install library stubs for mypy
         run: |
           make mypy-install-types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,16 @@ dependencies = [
     "requests"
 ]
 
+[project.optional-dependencies]
+dev = [
+    "black",
+    "flake8",
+    "mypy",
+]
+test = [
+    "responses",
+]
+
 # TODO
 #[project.scripts]
 #pwncollege-cli = "pwncollege_cli:main"


### PR DESCRIPTION
Define the development dependencies as the "dev" group and the test dependencies as the "test" group.

Adjust the CI GitHub Actions workflow in order to use them.
