### PR TITLE
Run tests via pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 BLACK = black
 FLAKE8 = flake8
 MYPY = mypy
+PYTEST = pytest
 PYTHON = python3
 
 all:
@@ -23,4 +24,4 @@ mypy:
 	@$(MYPY) --strict --exclude tests .
 
 test:
-	$(PYTHON) -m unittest discover -s tests -v
+	$(PYTEST) -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "mypy",
 ]
 test = [
+    "pytest",
     "responses",
 ]
 
@@ -56,3 +57,6 @@ Issues = "https://github.com/iamleot/pwncollege_cli/issues"
 [tool.black]
 # honor PEP 8
 line-length = 79
+
+[tool.pytest.ini_options]
+pythonpath = "src"


### PR DESCRIPTION
Switch to pytest as test runner and add the pythonpath-kludge in order to being able to run tests withot doing the "development mode" install via `pip install -e`.

(Please note though that doing the "development mode" install without any PYTHONPATH-kludge is still the recommended way.)
