### PR TITLE
Use setup-python cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup Python ${{ matrix.version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.version }}
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
+          cache: 'pip'
       - name: Install build and test dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
setup-python can do pip caching itself nowdays.

Switch to that instead of rolling our own caching via actions/cache.

While here also update to latest actions/setup-python major version.

NFCI.
